### PR TITLE
Suporte ao DirectCall

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ Você terá disponível globalmente o comando `gemidao-do-zap`.
 
 | Parâmetro | Obrigatório        | Descrição                                                 |
 |-----------|--------------------|-----------------------------------------------------------|
-| `--token` | :white_check_mark: | Seu token de acesso do TotalVoice                         |
+| `--token` | :white_check_mark: | Seu token de acesso do TotalVoice ou DirectCall           |
 | `--de`    |                    | Quem está enviando o gemidão? Qualquer número telefônico! |
 | `--para`  | :white_check_mark: | Quem é a vítima do gemidão do zap?                        |
 | `--sms`   |                    | Se definido, será enviado um SMS ao invés de uma chamada  |
+| `--api`   | :white_check_mark: | Escolha entre TotalVoice ou DirectCall                    |
 
 ### Exemplo
 
-`gemidao-do-zap --de=47998569631 --para=47996326548 --token=ade6a19ecee14577634f66af105eb68c`
+`gemidao-do-zap --de=47998569631 --para=47996326548 --api=TotalVoice --token=ade6a19ecee14577634f66af105eb68c`
 
 Observações:
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,8 @@ const emitError = message => console.log(red(` ✗ Erro: ${message}`));
 
 function cli(args) {
     gemidao(args)
-        .then(() => {
+        .then(res => {
+            console.log(res);
             emitSuccess(args.sms ? 'sms enviado!' : 'chamada efetuada!');
         })
         .catch(pipe(prop('message'), emitError));
@@ -33,6 +34,10 @@ cli(yargs
     .option('sms', {
         describe: 'Se definido, será enviado um SMS ao invés de uma chamada',
         type: 'boolean'
+    })
+    .option('api', {
+        describe: 'Escolha entre TotalVoice ou DirectCall (Padrão:TotalVoice)',
+        type: 'string'
     })
     .demandOption(['para', 'token'])
     .locale('pt_BR')

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -3,17 +3,19 @@ import agent from 'superagent';
 import promisifyAgent from 'superagent-promise';
 
 const request = promisifyAgent(agent, Bluebird);
-const route = path => `https://api.totalvoice.com.br${path}`;
+const routeDirectCall = pathDirectCall => `https://api.directcallsoft.com${path}`;
+const routeTotalVoice = pathTotalVoice => `https://api.totalvoice.com.br${path}`;
 
 const gemidaoInText = 'OOOWH AHHHWN WOOOO AAAAHN WAAAAA AAAAAAHN ANN WAAA!\n'
     + 'Voce caiu no gemidao do zap';
 
-const sms = (to, token) => request.post(route('/sms'))
+// TotalVoice
+const smsTotalVoice = (to, token) => request.post(routeTotalVoice('/sms'))
     .set('Access-Token', token)
     .set('Accept', 'application/json')
     .send({ numero_destino: to, mensagem: gemidaoInText });
 
-const call = (from, to, token) => request.post(route('/composto'))
+const callTotalVoice = (from, to, token) => request.post(routeTotalVoice('/composto'))
     .set('Access-Token', token)
     .set('Accept', 'application/json')
     .send({
@@ -29,18 +31,48 @@ const call = (from, to, token) => request.post(route('/composto'))
         bina: from
     });
 
+// DirectCall
+const smsDirectCall = (from, to, token) => request.post(route('/sms/send'))
+    .set('Accept', 'application/json')
+    .send({
+        origem: from,
+        access_token: token,
+        destino: to,
+        texto: gemidaoInText
+    });
+
+const callDirectCall = (from, to, token) => request.post(route('/sms/audio'))
+    .set('Access-Token', token)
+    .set('Accept', 'application/json')
+    .send({
+        access_token: token,
+        audio: 'https://github.com/haskellcamargo/gemidao-do-zap/raw/master/resources/gemidao.mp3'
+    });
+
+// Comum
 export default function gemidao(args) {
-    if (!/^[a-f0-9]{32}$/.test(args.token)) {
-        return reject(new Error('Token inválido. Obtenha um em https://totalvoice.com.br'));
+    if (!/^[a-f0-9]{45}$/.test(args.token)) {
+        return reject(new Error('Token inválido. Obtenha um em https://www.directcallsoft.com'));
     }
 
     if (!/^[0-9]{10,11}$/.test(args.para)) {
         return reject(new Error('Número de telefone inválido'));
     }
 
-    const action = args.sms
-        ? sms(args.para, args.token)
-        : call(args.de, args.para, args.token);
+    switch(args.api) {
+        case "TotalVoice":
+            const action = args.sms
+                ? smsTotalVoice(args.de, args.para, args.token)
+                : callTotalVoice(args.de, args.para, args.token);
+            break;
+        case "DirectCall":
+            const action = args.sms
+                ? smsDirectCall(args.de, args.para, args.token)
+                : callDirectCall(args.de, args.para, args.token);
+            break;
+        default:
+            return reject(new Error('Escolha uma das APIs Suportadas: DirectCall ou TotalVoice.'));
+    }
 
     return action
         .catch(err => {

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -74,9 +74,8 @@ export default function gemidao(args) {
                 return args.sms
                     ? smsDirectCall(args.de, args.para, args.token)
                     : callDirectCall(args.de, args.para, args.token);
-            } else {
-                return reject(new Error('Escolha uma das APIs Suportadas: DirectCall ou TotalVoice.'));
             }
+            return reject(new Error('Escolha uma das APIs Suportadas: DirectCall ou TotalVoice.'));
         })();
     return action
         .catch(err => {

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -62,7 +62,7 @@ export default function gemidao(args) {
             }
             
             const action = args.sms
-                ? smsTotalVoice(args.de, args.para, args.token)
+                ? smsTotalVoice(args.para, args.token)
                 : callTotalVoice(args.de, args.para, args.token);
             break;
         case "DirectCall":

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -54,16 +54,16 @@ export default function gemidao(args) {
         return reject(new Error('Número de telefone inválido'));
     }
 
-    const action =
-        (() => {
-            if (args.api.length === 0 || args.api === "TotalVoice") {
+    const action 
+    = (() => {
+            if (args.api.length === 0 || args.api === 'TotalVoice') {
                 if (!/^[a-f0-9]{32}$/.test(args.token)) {
                     return reject(new Error('Token inválido. Obtenha um em https://totalvoice.com.br'));
                 }
                 return args.sms
                     ? smsTotalVoice(args.para, args.token)
                     : callTotalVoice(args.de, args.para, args.token);
-            } else if (args.api === "DirectCall") {
+            } else if (args.api === 'DirectCall') {
                 // O token da DirectCall possui mais de 250 carecteres
                 // e nao tem tamanho definido, além de usar simbolos
                 //

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -32,7 +32,7 @@ const callTotalVoice = (from, to, token) => request.post(routeTotalVoice('/compo
     });
 
 // DirectCall
-const smsDirectCall = (from, to, token) => request.post(route('/sms/send'))
+const smsDirectCall = (from, to, token) => request.post(routeDirectCall('/sms/send'))
     .set('Accept', 'application/json')
     .send({
         origem: from,
@@ -41,7 +41,7 @@ const smsDirectCall = (from, to, token) => request.post(route('/sms/send'))
         texto: gemidaoInText
     });
 
-const callDirectCall = (from, to, token) => request.post(route('/sms/audio'))
+const callDirectCall = (from, to, token) => request.post(routeDirectCall('/sms/audio'))
     .set('Access-Token', token)
     .set('Accept', 'application/json')
     .send({

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -51,21 +51,25 @@ const callDirectCall = (from, to, token) => request.post(route('/sms/audio'))
 
 // Comum
 export default function gemidao(args) {
-    if (!/^[a-f0-9]{45}$/.test(args.token)) {
-        return reject(new Error('Token inválido. Obtenha um em https://www.directcallsoft.com'));
-    }
-
     if (!/^[0-9]{10,11}$/.test(args.para)) {
         return reject(new Error('Número de telefone inválido'));
     }
 
     switch(args.api) {
         case "TotalVoice":
+            if (!/^[a-f0-9]{32}$/.test(args.token)) {
+                return reject(new Error('Token inválido. Obtenha um em https://totalvoice.com.br'));
+            }
+            
             const action = args.sms
                 ? smsTotalVoice(args.de, args.para, args.token)
                 : callTotalVoice(args.de, args.para, args.token);
             break;
         case "DirectCall":
+            if (!/^[a-f0-9]{45}$/.test(args.token)) {
+                return reject(new Error('Token inválido. Obtenha um em https://www.directcallsoft.com'));
+            }
+            
             const action = args.sms
                 ? smsDirectCall(args.de, args.para, args.token)
                 : callDirectCall(args.de, args.para, args.token);


### PR DESCRIPTION
De acordo com o PR #11 criada pelo @luigifreitas, referente à issue #6 
Refatorei o código e estou fazendo esse PR para alguem continuar o trabalho a partir deste ponto onde já é possivel testar e fazer requisições para a API da DirectCall.
A maior dificuldade agora está justamente no fluxo da API deles e na não aceitação do meu Token dado como não informado.
Além disso essa chamada de API link somente cadastra o audio. Para fazer o envio da chamada é usada este método link com os parâmetros Origem, Destino e audio_id