### PR TITLE
Suporte a Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:boron
+
+RUN npm install -g gemidao-do-zap
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT "/entrypoint.sh" ; /bin/bash

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ A vítima receberá uma ligação e, quando atender, ouvirá o delicioso gemido 
 
 O arquivo encontra-se [neste link](http://prtnsrc.com/2545.mp3). Abra por sua conta e risco!
 
+## Docker
+
+Para quem quer rodar via Docker
+
+`$ docker build -t gemidao-do-zap -f Dockerfile .`
+`$ docker run --name gemidao-do-zap -e DE={{telefone}} -e PARA={{telefone}} -e TOKEN={{token}} gemidao-do-zap`
+
+
 ## Por quê!?
 
 Porque somos brasileiros!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+printenv
+gemidao-do-zap --de=$DE --para=$PARA --token=$TOKEN


### PR DESCRIPTION
Inclusão dos arquivos para suporte ao Docker.
Após o build da imagem, é possível rodar o script através do container docker com o seguinte comando:

`docker run --name gemidao-do-zap -e DE={{telefone}} -e PARA={{telefone}} -e TOKEN={{token}} gemidao-do-zap`