### PR TITLE
Reaproveitamento de Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,29 @@ Você terá disponível globalmente o comando `gemidao-do-zap`.
 
 ### Parâmetros
 
-| Parâmetro | Obrigatório        | Descrição                                                 |
-|-----------|--------------------|-----------------------------------------------------------|
-| `--token` | :white_check_mark: | Seu token de acesso do TotalVoice                         |
-| `--de`    |                    | Quem está enviando o gemidão? Qualquer número telefônico! |
-| `--para`  | :white_check_mark: | Quem é a vítima do gemidão do zap?                        |
-| `--sms`   |                    | Se definido, será enviado um SMS ao invés de uma chamada  |
+| Parâmetro    | Obrigatório        | Descrição                                                 |
+|--------------|--------------------|-----------------------------------------------------------|
+| `--token`    |                    | Seu token de acesso do TotalVoice                         |
+| `--de`       |                    | Quem está enviando o gemidão? Qualquer número telefônico! |
+| `--para`     | :white_check_mark: | Quem é a vítima do gemidão do zap?                        |
+| `--sms`      |                    | Se definido, será enviado um SMS ao invés de uma chamada  |
+| `--set_token`|                    | Se definido, salva o token como padrão.                   |
 
 ### Exemplo
 
 `gemidao-do-zap --de=47998569631 --para=47996326548 --token=ade6a19ecee14577634f66af105eb68c`
+
+### Reutilizando seu token
+
+É possível salvar o seu token como padrão para todas as chamadas com o comando `--set_token`.
+
+Assim, todas as suas próximas chamadas que não tiverem um token especificado usarão o token padrão.
+
+`gemidao-do-zap --para=47996326548 --token=ade6a19ecee14577634f66af105eb68c --set_token`
+
+Também é possível editar o token manualmente através do arquivo `config/default.json`
+
+OBS: É obrigatório o comando `--token` para que o `--set_token` funcione.
 
 Observações:
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,5 @@
+{
+  "TotalVoice": {
+    "Token": ""
+  }
+}

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
   "TotalVoice": {
-    "Token": ""
+    "Token": "ade6a19ecee14577634f66af105eb68c"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "colors": "^1.1.2",
+    "config": "^1.30.0",
     "ramda": "0.24.1",
     "superagent": "^3.5.2",
     "superagent-promise": "^1.1.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,11 @@ cli(yargs
         describe: 'Se definido, será enviado um SMS ao invés de uma chamada',
         type: 'boolean'
     })
-    .demandOption(['para', 'token'])
+    .option('set_token',{
+        describe: 'Se definido, salva o token como padrão.',
+        type: 'boolean'
+    })
+    .demandOption(['para'])
     .locale('pt_BR')
     .strict()
     .help()

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,7 @@ cli(yargs
         describe: 'Se definido, será enviado um SMS ao invés de uma chamada',
         type: 'boolean'
     })
-    .option('set_token',{
+    .option('set_token', {
         describe: 'Se definido, salva o token como padrão.',
         type: 'boolean'
     })

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -1,21 +1,20 @@
+import fs from 'fs';
 import Bluebird, { reject } from 'bluebird';
 import agent from 'superagent';
 import promisifyAgent from 'superagent-promise';
 import config from 'config';
-import fs from 'fs';
-import { green, yellow } from 'colors/safe'
+import { green, yellow } from 'colors/safe';
 
 const request = promisifyAgent(agent, Bluebird);
 const route = path => `https://api.totalvoice.com.br${path}`;
 const configFile = '../config/default.json';
 
-const setDefaultToken = (token) =>{
-    console.log("Diretorio: " + process.cwd());
-    var file = require(configFile);
+const setDefaultToken = token => {
+    console.log('Diretorio: ' + process.cwd());
+    let file;
+    file = require(configFile);
     file.TotalVoice.Token = token;
-    
-    let path = require('path').resolve(__dirname, configFile);
-    
+    const path = require('path').resolve(__dirname, configFile);
     fs.writeFile(path, JSON.stringify(file, null, 2),{encoding:'utf8',flag:'w'}, (err) => {
       if (err) {
             console.log(yellow('⚠ Não foi possível gravar o arquivo config.json: ' + err.message));
@@ -24,15 +23,12 @@ const setDefaultToken = (token) =>{
       console.log(green('✔ Token "'+token+'" definido como padrão.'));
     });
 }
-
 const gemidaoInText = 'OOOWH AHHHWN WOOOO AAAAHN WAAAAA AAAAAAHN ANN WAAA!\n'
     + 'Voce caiu no gemidao do zap';
-
 const sms = (to, token) => request.post(route('/sms'))
     .set('Access-Token', token)
     .set('Accept', 'application/json')
     .send({ numero_destino: to, mensagem: gemidaoInText });
-
 const call = (from, to, token) => request.post(route('/composto'))
     .set('Access-Token', token)
     .set('Accept', 'application/json')
@@ -48,14 +44,12 @@ const call = (from, to, token) => request.post(route('/composto'))
         ],
         bina: from
     });
-
 export default function gemidao(args) {
-    let token = args.token || config.get('TotalVoice.Token');
-    
+    let token;
+    token = args.token || config.get('TotalVoice.Token');
     if (!/^[a-f0-9]{32}$/.test(token)) {
         return reject(new Error('Token "'+token+'" inválido. Obtenha um em https://totalvoice.com.br'));
     }
-
     //Guarda o token na configuração, se desejado
     if (args.set_token) {
         if (!/^[a-f0-9]{32}$/.test(args.token)) {
@@ -63,21 +57,17 @@ export default function gemidao(args) {
         }
         setDefaultToken(args.token);
     }
-
     if (!/^[0-9]{10,11}$/.test(args.para)) {
         return reject(new Error('Número de telefone inválido: ' + args.para));
     }
-
     const action = args.sms
         ? sms(args.para, token)
         : call(args.de, args.para, token);
-
     return action
         .catch(err => {
             if (err.status === 405 || err.status === 403) {
                 return reject(new Error((err.body || err.response.body).mensagem));
             }
-
             return reject(err);
         });
 }

--- a/src/gemidao.js
+++ b/src/gemidao.js
@@ -1,9 +1,29 @@
 import Bluebird, { reject } from 'bluebird';
 import agent from 'superagent';
 import promisifyAgent from 'superagent-promise';
+import config from 'config';
+import fs from 'fs';
+import { green, yellow } from 'colors/safe'
 
 const request = promisifyAgent(agent, Bluebird);
 const route = path => `https://api.totalvoice.com.br${path}`;
+const configFile = '../config/default.json';
+
+const setDefaultToken = (token) =>{
+    console.log("Diretorio: " + process.cwd());
+    var file = require(configFile);
+    file.TotalVoice.Token = token;
+    
+    let path = require('path').resolve(__dirname, configFile);
+    
+    fs.writeFile(path, JSON.stringify(file, null, 2),{encoding:'utf8',flag:'w'}, (err) => {
+      if (err) {
+            console.log(yellow('⚠ Não foi possível gravar o arquivo config.json: ' + err.message));
+            return;
+      }
+      console.log(green('✔ Token "'+token+'" definido como padrão.'));
+    });
+}
 
 const gemidaoInText = 'OOOWH AHHHWN WOOOO AAAAHN WAAAAA AAAAAAHN ANN WAAA!\n'
     + 'Voce caiu no gemidao do zap';
@@ -30,17 +50,27 @@ const call = (from, to, token) => request.post(route('/composto'))
     });
 
 export default function gemidao(args) {
-    if (!/^[a-f0-9]{32}$/.test(args.token)) {
-        return reject(new Error('Token inválido. Obtenha um em https://totalvoice.com.br'));
+    let token = args.token || config.get('TotalVoice.Token');
+    
+    if (!/^[a-f0-9]{32}$/.test(token)) {
+        return reject(new Error('Token "'+token+'" inválido. Obtenha um em https://totalvoice.com.br'));
+    }
+
+    //Guarda o token na configuração, se desejado
+    if (args.set_token) {
+        if (!/^[a-f0-9]{32}$/.test(args.token)) {
+            return reject(new Error('O comando "--set_token" requer um token TotalVoice válido. Obtenha um em https://totalvoice.com.br'));
+        }
+        setDefaultToken(args.token);
     }
 
     if (!/^[0-9]{10,11}$/.test(args.para)) {
-        return reject(new Error('Número de telefone inválido'));
+        return reject(new Error('Número de telefone inválido: ' + args.para));
     }
 
     const action = args.sms
-        ? sms(args.para, args.token)
-        : call(args.de, args.para, args.token);
+        ? sms(args.para, token)
+        : call(args.de, args.para, token);
 
     return action
         .catch(err => {


### PR DESCRIPTION

Adicionado o comando `--set_token` para salvar o token especificado como configuração padrão.

Após salvo, qualquer chamada utilizará o token especificado como padrão, **a menos que** algum outro seja especificado.

Ao invés de fazer três chamadas assim:
`gemida-do-zap --para 11987655678 --token ade6a19ecee14577634f66af105eb68c`
`gemida-do-zap --para 11982716721 --token ade6a19ecee14577634f66af105eb68c`
`gemida-do-zap --para 11920819273 --token ade6a19ecee14577634f66af105eb68c`

Serão feitas assim:
`gemida-do-zap --para 11987655678 --token ade6a19ecee14577634f66af105eb68c --set_token`
`gemida-do-zap --para 11982716721`
`gemida-do-zap --para 11920819273`

Para que isso seja possível, o comando `--token` não é mais obrigatório.

Caso queira utilizar um token diferente, basta especificá-lo novamente:
`gemida-do-zap --para 11987655678 --token TOKEN1 --set_token`
`gemida-do-zap --para 11982716721` >> Utiliza o TOKEN1
`gemida-do-zap --para 11920819273 --token TOKEN2` > Utiliza o TOKEN2
`gemida-do-zap --para 11920819273` >> Volta a utilizar o TOKEN1 configurado.
