### PR TITLE
Correcting docker command options order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Para quem quer rodar via Docker
 $ docker build -t gemidao-do-zap -f Dockerfile .
 ```
 ```
-$ docker run --name --rm gemidao-do-zap -e DE={{telefone}} -e PARA={{telefone}} -e TOKEN={{token}} gemidao-do-zap
+$ docker run --rm --name gemidao-do-zap -e DE={{telefone}} -e PARA={{telefone}} -e TOKEN={{token}} gemidao-do-zap
 ```
 
 


### PR DESCRIPTION
Changing docker options order to work properly for those who desire to do just [ctrl]+[c] and [ctrl]+[v]